### PR TITLE
Update to 1.16.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'maven-publish'
 	id 'idea'
 	id 'eclipse'
-	id 'com.matthewprenger.cursegradle' version '1.0.9'
+	id 'com.matthewprenger.cursegradle' version '1.4.0'
 	id 'fabric-loom' version '0.4-SNAPSHOT'
 }
 
@@ -21,7 +21,7 @@ minecraft {
 }
 
 repositories {
-	maven { url 'https://jitpack.io' }
+	jcenter()
 }
 
 dependencies {
@@ -29,8 +29,8 @@ dependencies {
 	mappings "net.fabricmc:yarn:${mappings_version}"
 	modCompile "net.fabricmc:fabric-loader:${fabric_loader_version}"
 	modCompile "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
-	modCompile "com.github.Ladysnake:Satin:${satin_version}"
-	include "com.github.Ladysnake:Satin:${satin_version}"
+	modCompile "io.github.ladysnake:Satin:${satin_version}"
+	include "io.github.ladysnake:Satin:${satin_version}"
 	
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-minecraft_version=1.16-rc1
+minecraft_version=1.16.2
 
-mod_version=1.0.5
+mod_version=1.0.6
 
-fabric_loader_version=0.8.8+build.202
-fabric_version=0.12.5+build.367-1.16
-mappings_version=1.16-rc1+build.8
+fabric_loader_version=0.9.1+build.205
+fabric_version=0.18.0+build.397-1.16
+mappings_version=1.16.2+build.19
 
 # Satin library
-satin_version = 1.16-SNAPSHOT
+satin_version = 1.4.1
 
 project_id=268324
 release_type=release

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.16.2
 
-mod_version=1.0.6
+mod_version=1.0.7
 
 fabric_loader_version=0.9.1+build.205
 fabric_version=0.18.0+build.397-1.16

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/src/main/java/com/tterrag/blur/mixin/MixinMinecraftClient.java
+++ b/src/main/java/com/tterrag/blur/mixin/MixinMinecraftClient.java
@@ -20,7 +20,7 @@ public class MixinMinecraftClient {
             at = @At(value = "FIELD",
                      target = "Lnet/minecraft/client/MinecraftClient;currentScreen:Lnet/minecraft/client/gui/screen/Screen;",
                      opcode = Opcodes.PUTFIELD))
-    public void onScreenOpen(Screen newScreen, CallbackInfo info) {
+    private void onScreenOpen(Screen newScreen, CallbackInfo info) {
         Blur.INSTANCE.onScreenChange(newScreen);
     }
 }

--- a/src/main/java/com/tterrag/blur/mixin/MixinScreen.java
+++ b/src/main/java/com/tterrag/blur/mixin/MixinScreen.java
@@ -14,14 +14,14 @@ public class MixinScreen {
     @ModifyConstant(
             method = "renderBackground(Lnet/minecraft/client/util/math/MatrixStack;I)V",
             constant = @Constant(intValue = -1072689136))
-    public int getFirstBackgroundColor(int color) {
+    private int getFirstBackgroundColor(int color) {
         return Blur.INSTANCE.getBackgroundColor(false);
     }
 
     @ModifyConstant(
             method = "renderBackground(Lnet/minecraft/client/util/math/MatrixStack;I)V",
             constant = @Constant(intValue = -804253680))
-    public int getSecondBackgroundColor(int color) {
+    private int getSecondBackgroundColor(int color) {
         return Blur.INSTANCE.getBackgroundColor(true);
     }
 }


### PR DESCRIPTION
This PR updates Blur to 1.16.2, using the latest Satin version. I also took the opportunity to refactor config loading (`FabricLoader#getConfigDirectory` has been deprecated).