### PR TITLE
Fix internal version of mod

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "blur",
   "name": "Blur (Fabric)",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "environment": "client",
   "license": "MIT",
   "icon": "assets/blur/icon.png",


### PR DESCRIPTION
Some mods/tools like [Mod Manager](https://github.com/DeathsGun/ModManager) look at this version, in case of an update. If this version isn't properly updated, the affected mods _are_ the new, updated version in the /mods folder (in my case 2.3,0), but the mod _thinks_ it's running the version listed (in my case 2.1.0). So I made a quick version bump, and please @Motschen, make sure to _always_ update this version number _ahead_ of release. Thanks!