### PR TITLE
Add AdvancedChat to the exclusion list

### DIFF
--- a/src/main/java/com/tterrag/blur/Blur.java
+++ b/src/main/java/com/tterrag/blur/Blur.java
@@ -34,6 +34,7 @@ public class Blur implements ClientModInitializer {
         defaultExclusions.add("com.replaymod.lib.de.johni0702.minecraft.gui.container.AbstractGuiOverlay$UserInputGuiScreen");
         defaultExclusions.add("ai.arcblroth.projectInception.client.InceptionInterfaceScreen");
         defaultExclusions.add("net.optifine.gui.GuiChatOF");
+        defaultExclusions.add("io.github.darkkronicle.advancedchatcore.chat.AdvancedChatScreen");
         BlurConfig.init("blur", BlurConfig.class);
 
         ShaderEffectRenderCallback.EVENT.register((deltaTick) -> {


### PR DESCRIPTION
This PR adds the chat from [AdvancedChat](https://github.com/DarkKronicle/AdvancedChatCore/) to the default list of exclusions.