### PR TITLE
Update Dependencys for Minecraft 1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.1
-	loader_version=0.14.6
+	minecraft_version=1.19.2
+	yarn_mappings=1.19.2+build.8
+	loader_version=0.14.9
 	
 # Mod Properties
-	mod_version = 2.6.0
+	mod_version = 2.6.1
 	maven_group = com.tterrag.blur
 	archives_base_name = blur
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.55.1+1.19
-	satin_version = 1.8.0
-	midnightlib_version=0.5.2
+	fabric_version=0.60.0+1.19.2
+	satin_version = 1.9.0
+	midnightlib_version=0.6.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**New update Dependencys**
-Gradle 7.5.1

Fabric components
-Game 1.19.2
-yarn 1.19.2 build+8
-loader 0.14.9
-api 0.60.0

-Satin 1.9.0
-midnightlib 0.6.0