### PR TITLE
Add Iris's shader pack screen to the exclusion list

### DIFF
--- a/src/main/java/com/tterrag/blur/Blur.java
+++ b/src/main/java/com/tterrag/blur/Blur.java
@@ -35,6 +35,7 @@ public class Blur implements ClientModInitializer {
         defaultExclusions.add("ai.arcblroth.projectInception.client.InceptionInterfaceScreen");
         defaultExclusions.add("net.optifine.gui.GuiChatOF");
         defaultExclusions.add("io.github.darkkronicle.advancedchatcore.chat.AdvancedChatScreen");
+        defaultExclusions.add("net.coderbot.iris.gui.screen.ShaderPackScreen");
         BlurConfig.init("blur", BlurConfig.class);
 
         ShaderEffectRenderCallback.EVENT.register((deltaTick) -> {


### PR DESCRIPTION
[Iris 1.4](https://github.com/IrisShaders/Iris/blob/trunk/docs/changelogs/1.4.0/full.md) added a button to the shader pack screen that temporarily hides the GUI so that you can quickly see the effects of the changes you're making. However, this acts weird with Blur because the blur effect is still shown even when the GUI isn't, so you can't really see much.

This PR simply adds a default exclusion for [`net.coderbot.iris.gui.screen.ShaderPackScreen`](https://github.com/IrisShaders/Iris/blob/trunk/src/main/java/net/coderbot/iris/gui/screen/ShaderPackScreen.java) to solve this!