### PR TITLE
Expend build environment JAVA 19 + Update midnightlib 1.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.64.0+1.19.2
+	fabric_version=0.66.0+1.19.2
 	satin_version = 1.9.0
 	midnightlib_version=1.0.0-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.64.0+1.19.2
 	satin_version = 1.9.0
-	midnightlib_version=0.6.1
+	midnightlib_version=1.0.0-fabric

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7.6 will start support Java 19.
I set my dev envirmoment to Java 19 and tested on gradle 7.6
All builds working fine, and in-game work is fine too.
And I confirmed midnightlib updated 1.0.0
enjoy!
