### PR TITLE
1.19.4 update

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: [ "fabric-1.19.3" ]
+    branches: [ "fabric-1.19.4" ]
   pull_request:
-    branches: [ "fabric-1.19.3" ]
+    branches: [ "fabric-1.19.4" ]
 
 permissions:
   contents: read

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.0-SNAPSHOT'
+	id 'fabric-loom' version '1.1-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,14 +12,6 @@ group = project.maven_group
 
 repositories {
 	maven {
-		name = 'Ladysnake Mods'
-		url = 'https://ladysnake.jfrog.io/artifactory/mods'
-		content {
-			includeGroup 'io.github.ladysnake'
-			includeGroupByRegex 'io\\.github\\.onyxstudios.*'
-		}
-	}
-	maven {
 		url = 'https://maven.terraformersmc.com/releases'
 		content {
 			includeGroup 'com.terraformersmc'
@@ -36,8 +28,8 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	modImplementation "io.github.ladysnake:satin:${satin_version}"
-	include "io.github.ladysnake:satin:${satin_version}"
+	modImplementation "maven.modrinth:satin-api:${satin_version}"
+	include "maven.modrinth:satin-api:${satin_version}"
 
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 	modImplementation "maven.modrinth:midnightlib:${project.midnightlib_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.3
-	loader_version=0.14.11
+	yarn_mappings=1.19.3+build.5
+	loader_version=0.14.12
 	
 # Mod Properties
-	mod_version = 2.6.2
+	mod_version = 2.6.1
 	maven_group = com.tterrag.blur
 	archives_base_name = blur
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.69.0+1.19.3
+	fabric_version=0.71.0+1.19.3
 	satin_version = 1.10.0
 	midnightlib_version=1.1.0-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.19.3
 	yarn_mappings=1.19.3+build.5
-	loader_version=0.14.12
+	loader_version=0.14.14
 	
 # Mod Properties
 	mod_version = 2.6.1
@@ -14,6 +14,6 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.71.0+1.19.3
+	fabric_version=0.73.2+1.19.3
 	satin_version = 1.10.0
 	midnightlib_version=1.1.0-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.19.3
 	yarn_mappings=1.19.3+build.5
-	loader_version=0.14.14
+	loader_version=0.14.17
 	
 # Mod Properties
 	mod_version = 2.6.1
@@ -14,6 +14,6 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.73.2+1.19.3
+	fabric_version=0.75.1+1.19.3
 	satin_version = 1.10.0
 	midnightlib_version=1.1.0-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.5
+	minecraft_version=1.19.4
+	yarn_mappings=1.19.4+build.1
 	loader_version=0.14.17
 	
 # Mod Properties
-	mod_version = 2.6.1
+	mod_version = 2.6.2
 	maven_group = com.tterrag.blur
 	archives_base_name = blur
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.76.0+1.19.3
-	satin_version = 1.10.0
-	midnightlib_version=1.1.0-fabric
+	satin_version = 1.11.0
+	midnightlib_version=1.2.1-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.75.1+1.19.3
+	fabric_version=0.76.0+1.19.3
 	satin_version = 1.10.0
 	midnightlib_version=1.1.0-fabric

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/tterrag/blur/mixin/MixinScreen.java
+++ b/src/main/java/com/tterrag/blur/mixin/MixinScreen.java
@@ -36,14 +36,14 @@ public abstract class MixinScreen {
     }
 
     @ModifyConstant(
-            method = "renderBackground(Lnet/minecraft/client/util/math/MatrixStack;I)V",
+            method = "Lnet/minecraft/class_437;method_25420(Lnet/minecraft/class_4587;)V",
             constant = @Constant(intValue = -1072689136))
     private int blur$getFirstBackgroundColor(int color) {
         return Blur.INSTANCE.getBackgroundColor(false);
     }
 
     @ModifyConstant(
-            method = "renderBackground(Lnet/minecraft/client/util/math/MatrixStack;I)V",
+            method = "Lnet/minecraft/class_437;method_25420(Lnet/minecraft/class_4587;)V",
             constant = @Constant(intValue = -804253680))
     private int blur$getSecondBackgroundColor(int color) {
         return Blur.INSTANCE.getBackgroundColor(true);


### PR DESCRIPTION
midnightlib and satin finaly support 1.19.4!
so I ported blur fastly on 1.19.4 fabric.
Set all deps recent, test on in-game and No problem in test!
I hope this commit will helpful.

ps. last commit is mistake, just ignore it.(c32a10f)