### PR TITLE
Fix crash when Blur.prevScreen is null

### DIFF
--- a/src/main/java/com/tterrag/blur/mixin/MixinInGameHud.java
+++ b/src/main/java/com/tterrag/blur/mixin/MixinInGameHud.java
@@ -19,7 +19,7 @@ public class MixinInGameHud {
     @Final @Shadow private MinecraftClient client;
     @Inject(at = @At("TAIL"), method = "render")
     public void blur$onRender(DrawContext context, float tickDelta, CallbackInfo ci) {
-        if (client.currentScreen == null && client.world != null && Blur.start > 0 && BlurConfig.blurExclusions.stream().noneMatch(exclusion -> Blur.prevScreen.startsWith(exclusion)) && Blur.screenHasBackground) {
+        if (client.currentScreen == null && client.world != null && Blur.start > 0 && (Blur.prevScreen == null || BlurConfig.blurExclusions.stream().noneMatch(exclusion -> Blur.prevScreen.startsWith(exclusion))) && Blur.screenHasBackground) {
             context.fillGradient(0, 0, this.scaledWidth, this.scaledHeight, Blur.getBackgroundColor(false, false), Blur.getBackgroundColor(true, false));
         }
     }


### PR DESCRIPTION
Blur.prevScreen can be nulll which sometimes causes a crash when you join a server or die without opening any gui previously. This adds a simple check for that case.