### PR TITLE
[Feature] Fully Continuous Animations & Reduced Blur on In-Game Screens (off by default)

### DIFF
--- a/src/main/java/eu/midnightdust/blur/Blur.java
+++ b/src/main/java/eu/midnightdust/blur/Blur.java
@@ -1,10 +1,7 @@
 package eu.midnightdust.blur;
 
-import eu.midnightdust.blur.animations.impl.FadeAnimationTarget;
-import eu.midnightdust.blur.animations.impl.GradientAnimationTarget;
-import eu.midnightdust.blur.animations.impl.GradientAnimationHandler;
+import eu.midnightdust.blur.animations.impl.*;
 import eu.midnightdust.blur.config.BlurConfig;
-import eu.midnightdust.blur.animations.impl.FadeAnimationHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 
@@ -46,12 +43,13 @@ public class Blur {
 
     public static Minecraft minecraft = Minecraft.getInstance();
 
-    public static final FadeAnimationHandler blurRadiusAnimation = new FadeAnimationHandler();
-    public static final FadeAnimationHandler backgroundAlphaAnimation = new FadeAnimationHandler();
+    public static final BlurRadiusAnimationHandler blurRadiusAnimation = new BlurRadiusAnimationHandler();
+    public static final BackgroundAlphaAnimationHandler backgroundAlphaAnimation = new BackgroundAlphaAnimationHandler();
     public static final GradientAnimationHandler gradientAnimation = new GradientAnimationHandler();
 
     public static boolean isProcessingRenderPass = false;
     public static boolean forceRenderedBackground = false;
+    public static boolean reducedBlur = false;
 
     public static float getGameTimeDeltaTicks() {
         //? if >= 1.21.5 {
@@ -92,9 +90,10 @@ public class Blur {
         }
         if (!isProcessingRenderPass) {
             isProcessingRenderPass = true;
-            blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeOut);
-            backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeOut);
+            blurRadiusAnimation.setTarget(BlurRadiusAnimationTarget.FadeOut);
+            backgroundAlphaAnimation.setTarget(BackgroundAlphaAnimationTarget.FadeOut);
             forceRenderedBackground = false;
+            reducedBlur = false;
         } else {
             Blur.LOGGER.debug("onRender has been called multiple times in one render pass: {}, " +
                             "blur radius animation target: {}, background alpha animation target: {}",
@@ -209,14 +208,14 @@ public class Blur {
 
             // force a background fade-in animation for forceEnabledScreens
             if (screenName != null &&BlurConfig.forceEnabledScreens.contains(screenName)) {
-                blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeIn);
-                backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeIn);
+                blurRadiusAnimation.setTarget(BlurRadiusAnimationTarget.FadeIn);
+                backgroundAlphaAnimation.setTarget(BackgroundAlphaAnimationTarget.FadeIn);
             }
 
             // force a background fade-out animation for forceDisabledScreens
             if (screenName != null && BlurConfig.forceDisabledScreens.contains(screenName)) {
-                blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeOut);
-                backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeOut);
+                blurRadiusAnimation.setTarget(BlurRadiusAnimationTarget.FadeOut);
+                backgroundAlphaAnimation.setTarget(BackgroundAlphaAnimationTarget.FadeOut);
             }
 
             // update gradientAnimation target from config

--- a/src/main/java/eu/midnightdust/blur/Blur.java
+++ b/src/main/java/eu/midnightdust/blur/Blur.java
@@ -1,7 +1,7 @@
 package eu.midnightdust.blur;
 
-import eu.midnightdust.blur.animations.impl.FadeAnimationState;
-import eu.midnightdust.blur.animations.impl.GradientAnimationState;
+import eu.midnightdust.blur.animations.impl.FadeAnimationTarget;
+import eu.midnightdust.blur.animations.impl.GradientAnimationTarget;
 import eu.midnightdust.blur.animations.impl.GradientAnimationHandler;
 import eu.midnightdust.blur.config.BlurConfig;
 import eu.midnightdust.blur.animations.impl.FadeAnimationHandler;
@@ -25,7 +25,6 @@ import org.joml.Matrix3x2f;
 //? fabric {
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 //?} else if neoforge {
 /*import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.common.Mod;
@@ -93,20 +92,20 @@ public class Blur {
         }
         if (!isProcessingRenderPass) {
             isProcessingRenderPass = true;
-            blurRadiusAnimation.setState(FadeAnimationState.FadeOut);
-            backgroundAlphaAnimation.setState(FadeAnimationState.FadeOut);
+            blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeOut);
+            backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeOut);
             forceRenderedBackground = false;
         } else {
             Blur.LOGGER.debug("onRender has been called multiple times in one render pass: {}, " +
-                            "blur radius animation state: {}, background alpha animation state: {}",
-                    minecraft.screen, blurRadiusAnimation.getState(), backgroundAlphaAnimation.getState()
+                            "blur radius animation target: {}, background alpha animation target: {}",
+                    minecraft.screen, blurRadiusAnimation.getTarget(), backgroundAlphaAnimation.getTarget()
             );
         }
     }
 
     //~ if >= 26.1 'GuiGraphics' -> 'GuiGraphicsExtractor'
     public static void renderBlurredBackground(GuiGraphicsExtractor context) {
-        if (blurRadiusAnimation.getProgress() < 0.001F) return; // there's no blur to apply
+        if (blurRadiusAnimation.getCurrentValue() < 0.001F) return; // there's no blur to apply
 
         //? if > 1.21.5 {
         if (Blur.canBlur(context))
@@ -128,8 +127,8 @@ public class Blur {
             forceRenderedBackground = true;
         } else {
             Blur.LOGGER.debug("renderBackground has been called multiple times in one render pass: {}, " +
-                            "blur radius animation state: {}, background alpha animation state: {}",
-                    minecraft.screen, blurRadiusAnimation.getState(), backgroundAlphaAnimation.getState()
+                            "blur radius animation target: {}, background alpha animation target: {}",
+                    minecraft.screen, blurRadiusAnimation.getTarget(), backgroundAlphaAnimation.getTarget()
             );
         }
     }
@@ -139,7 +138,7 @@ public class Blur {
         int red = color.getRed();
         int green = color.getGreen();
         int blue = color.getBlue();
-        int alpha = (int) (backgroundAlphaAnimation.getProgress() * color.getAlpha());
+        int alpha = (int) (backgroundAlphaAnimation.getCurrentValue() * color.getAlpha());
         return alpha << 24 | red << 16 | green << 8 | blue;
     }
 
@@ -149,7 +148,7 @@ public class Blur {
 
     //~ if >= 26.1 'GuiGraphics' -> 'GuiGraphicsExtractor'
     public static void renderRotatedGradient(GuiGraphicsExtractor context) {
-        if (!BlurConfig.useGradient || backgroundAlphaAnimation.getProgress() < 0.001F) return;  // there's no gradient to draw
+        if (!BlurConfig.useGradient || backgroundAlphaAnimation.getCurrentValue() < 0.001F) return;  // there's no gradient to draw
 
         int width = context.guiWidth();
         int height = context.guiHeight();
@@ -200,8 +199,8 @@ public class Blur {
         // animation calculations for this screen
         if (isProcessingRenderPass) {
             Blur.LOGGER.debug("processed render pass: {}," +
-                            "blur radius animation state: {}, background alpha animation state: {}",
-                    minecraft.screen, blurRadiusAnimation.getState(), backgroundAlphaAnimation.getState()
+                            "blur radius animation target: {}, background alpha animation target: {}",
+                    minecraft.screen, blurRadiusAnimation.getTarget(), backgroundAlphaAnimation.getTarget()
             );
             String screenName = null;
             if (minecraft.screen != null) {
@@ -210,26 +209,26 @@ public class Blur {
 
             // force a background fade-in animation for forceEnabledScreens
             if (screenName != null &&BlurConfig.forceEnabledScreens.contains(screenName)) {
-                blurRadiusAnimation.setState(FadeAnimationState.FadeIn);
-                backgroundAlphaAnimation.setState(FadeAnimationState.FadeIn);
+                blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeIn);
+                backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeIn);
             }
 
             // force a background fade-out animation for forceDisabledScreens
             if (screenName != null && BlurConfig.forceDisabledScreens.contains(screenName)) {
-                blurRadiusAnimation.setState(FadeAnimationState.FadeOut);
-                backgroundAlphaAnimation.setState(FadeAnimationState.FadeOut);
+                blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeOut);
+                backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeOut);
             }
 
-            // update gradientAnimation state from config
-            gradientAnimation.setState(BlurConfig.rainbowMode ? GradientAnimationState.Rainbow : GradientAnimationState.Fixed);
+            // update gradientAnimation target from config
+            gradientAnimation.setTarget(BlurConfig.rainbowMode ? GradientAnimationTarget.Rainbow : GradientAnimationTarget.Fixed);
 
             updateAnimations();
 
             isProcessingRenderPass = false;
         }  else {
             Blur.LOGGER.debug("onRenderEnd has been called multiple times in one render pass: {}," +
-                            "blur radius animation state: {}, background alpha animation state: {}",
-                    minecraft.screen, blurRadiusAnimation.getState(), backgroundAlphaAnimation.getState()
+                            "blur radius animation target: {}, background alpha animation target: {}",
+                    minecraft.screen, blurRadiusAnimation.getTarget(), backgroundAlphaAnimation.getTarget()
             );
         }
     }

--- a/src/main/java/eu/midnightdust/blur/animations/AbstractAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/AbstractAnimationHandler.java
@@ -1,73 +1,71 @@
 package eu.midnightdust.blur.animations;
 
+import eu.midnightdust.blur.Blur;
 import eu.midnightdust.blur.config.BlurConfig;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Math;
 
-public abstract class AbstractAnimationHandler<E extends Enum<E>> implements IAnimationHandler<E> {
-    private float timeState = 0.0F;
-    private float progress = 0.0F;
-    private E state = null;
 
-    public AnimationState stepAnimation(float deltaSeconds, BlurConfig.Easing easing, AnimationState oldAnimationState) {
-        return oldAnimationState;
-    }
+public abstract class AbstractAnimationHandler<E extends Enum<E> & IEnumAnimationTarget> implements IAnimationHandler<E> {
+    private AnimationState<E> state = new AnimationState<E>(
+            0.0F,
+            0.0F,
+            0.0F,
+            null
+    );
+    private E newTarget = null;
 
-    public AnimationState stepForward(float deltaSeconds, BlurConfig.Easing easing, AnimationState oldAnimationState) {
-        float newTimeState;
-        float newProgress;
+    public AnimationState<E> stepAnimation(float deltaSeconds, BlurConfig.Easing easing) {
+        float newTimeState = Math.clamp(0, 1, getTimeState() + (1000 * deltaSeconds / BlurConfig.fadeTimeMillis));
 
-        if (BlurConfig.fadeTimeMillis > 0) {
-            newTimeState = Math.clamp(0, 1, oldAnimationState.timeState() + (1000 * deltaSeconds / BlurConfig.fadeTimeMillis));
-            newProgress = Math.clamp(0, 1, easing.apply((double) newTimeState).floatValue());
-        } else {
-            newTimeState = 1.0F;
-            newProgress = 1.0F;
-        }
+        var newValue = Math.lerp(state.startValue(), state.target().getAnimationTarget(), easing.apply((double) newTimeState).floatValue());
 
-        return new AnimationState(newTimeState, newProgress);
-    }
-
-    public AnimationState stepBackward(float deltaSeconds, BlurConfig.Easing easing, AnimationState oldAnimationState) {
-        float newTimeState;
-        float newProgress;
-
-        if (BlurConfig.fadeOutTimeMillis > 0) {
-            newTimeState = Math.clamp(0, 1, oldAnimationState.timeState() - (1000 * deltaSeconds / BlurConfig.fadeOutTimeMillis));
-            newProgress = Math.clamp(0, 1, 1 - easing.apply((double) 1 - newTimeState).floatValue());
-        } else {
-            newTimeState = 0.0F;
-            newProgress = 0.0F;
-        }
-
-        return new AnimationState(newTimeState, newProgress);
+        return new AnimationState<E>(newTimeState, state.startValue(), newValue, state.target());
     }
 
     @Override
     public void updateAnimation(float deltaSeconds, BlurConfig.Easing easing) {
-        if (state == null || deltaSeconds <= 0) return;
+        if (BlurConfig.fadeTimeMillis == 0 || deltaSeconds <= 0) return;
+        if (newTarget != null) resetTimeState();
+        if (getTarget() == null) return;
         // actually update the animation
-        AnimationState newAnimationState = stepAnimation(deltaSeconds, easing, new AnimationState(getTimeState(), getProgress()));
-        timeState = newAnimationState.timeState();
-        progress = newAnimationState.progress();
+        state = stepAnimation(deltaSeconds, easing);
     }
 
     @Override
-    public float getProgress() {
-        return progress;
+    public float getCurrentValue() {
+        return state.currentValue();
     }
 
     @Override
     public float getTimeState() {
-        return timeState;
+        return state.timeState();
     }
 
     @Override
-    public E getState() {
-        return state;
+    public @Nullable E getTarget() {
+        return state.target();
     }
 
     @Override
-    public void setState(E state) {
-        this.state = state;
+    public void setTarget(E target) {
+        if (target == newTarget) return;
+        if (target == getTarget()) {
+            newTarget = null;
+        } else {
+            newTarget = target;
+        }
+    }
+
+    private void resetTimeState() {
+        Blur.LOGGER.debug("New Animation Target: {}", newTarget);
+
+        state = new AnimationState<E>(
+                0.0F,
+                getCurrentValue(),
+                getCurrentValue(),
+                newTarget
+        );
+        newTarget = null;
     }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/AbstractAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/AbstractAnimationHandler.java
@@ -16,7 +16,7 @@ public abstract class AbstractAnimationHandler<E extends Enum<E> & IEnumAnimatio
     private E newTarget = null;
 
     public AnimationState<E> stepAnimation(float deltaSeconds, BlurConfig.Easing easing) {
-        float newTimeState = Math.clamp(0, 1, getTimeState() + (1000 * deltaSeconds / getFadeTimeMillis()));
+        float newTimeState = Math.clamp(0, 1, getTimeState() + (1000 * deltaSeconds / getAnimationTimeMillis()));
 
         var newValue = Math.lerp(state.startValue(), state.target().getAnimationTarget(), easing.apply((double) newTimeState).floatValue());
 
@@ -24,13 +24,16 @@ public abstract class AbstractAnimationHandler<E extends Enum<E> & IEnumAnimatio
     }
 
     @Override
-    public int getFadeTimeMillis() {
-        return BlurConfig.fadeTimeMillis;
+    public int getAnimationTimeMillis() {
+        if (getTarget() == null) {
+            return BlurConfig.fadeTimeMillis;
+        }
+        return getTarget().getAnimationTimeMillis();
     }
 
     @Override
     public void updateAnimation(float deltaSeconds, BlurConfig.Easing easing) {
-        if (getFadeTimeMillis() == 0 || deltaSeconds <= 0) return;
+        if (getAnimationTimeMillis() == 0 || deltaSeconds <= 0) return;
         if (newTarget != null){
             resetTarget(newTarget);
             newTarget = null;

--- a/src/main/java/eu/midnightdust/blur/animations/AbstractAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/AbstractAnimationHandler.java
@@ -16,7 +16,7 @@ public abstract class AbstractAnimationHandler<E extends Enum<E> & IEnumAnimatio
     private E newTarget = null;
 
     public AnimationState<E> stepAnimation(float deltaSeconds, BlurConfig.Easing easing) {
-        float newTimeState = Math.clamp(0, 1, getTimeState() + (1000 * deltaSeconds / BlurConfig.fadeTimeMillis));
+        float newTimeState = Math.clamp(0, 1, getTimeState() + (1000 * deltaSeconds / getFadeTimeMillis()));
 
         var newValue = Math.lerp(state.startValue(), state.target().getAnimationTarget(), easing.apply((double) newTimeState).floatValue());
 
@@ -24,9 +24,17 @@ public abstract class AbstractAnimationHandler<E extends Enum<E> & IEnumAnimatio
     }
 
     @Override
+    public int getFadeTimeMillis() {
+        return BlurConfig.fadeTimeMillis;
+    }
+
+    @Override
     public void updateAnimation(float deltaSeconds, BlurConfig.Easing easing) {
-        if (BlurConfig.fadeTimeMillis == 0 || deltaSeconds <= 0) return;
-        if (newTarget != null) resetTimeState();
+        if (getFadeTimeMillis() == 0 || deltaSeconds <= 0) return;
+        if (newTarget != null){
+            resetTarget(newTarget);
+            newTarget = null;
+        }
         if (getTarget() == null) return;
         // actually update the animation
         state = stepAnimation(deltaSeconds, easing);
@@ -57,15 +65,14 @@ public abstract class AbstractAnimationHandler<E extends Enum<E> & IEnumAnimatio
         }
     }
 
-    private void resetTimeState() {
-        Blur.LOGGER.debug("New Animation Target: {}", newTarget);
+    public void resetTarget(E target) {
+        Blur.LOGGER.debug("New Animation Target: {}", target);
 
         state = new AnimationState<E>(
                 0.0F,
                 getCurrentValue(),
                 getCurrentValue(),
-                newTarget
+                target
         );
-        newTarget = null;
     }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/AnimationState.java
+++ b/src/main/java/eu/midnightdust/blur/animations/AnimationState.java
@@ -1,5 +1,7 @@
 package eu.midnightdust.blur.animations;
 
-public record AnimationState(float timeState, float progress) {
+import org.jetbrains.annotations.Nullable;
+
+public record AnimationState<E extends Enum<E> & IEnumAnimationTarget>(float timeState, float startValue, float currentValue, @Nullable E target) {
 
 }

--- a/src/main/java/eu/midnightdust/blur/animations/IAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/IAnimationHandler.java
@@ -2,13 +2,10 @@ package eu.midnightdust.blur.animations;
 
 import eu.midnightdust.blur.config.BlurConfig;
 
-public interface IAnimationHandler<E extends Enum<E>> {
+public interface IAnimationHandler<E extends Enum<E> & IEnumAnimationTarget> {
     void updateAnimation(float deltaSeconds, BlurConfig.Easing easing);
-    default void updateAnimation(float deltaSeconds) {
-        updateAnimation(deltaSeconds, BlurConfig.Easing.FLAT);
-    }
-    void setState(E state);
+    void setTarget(E target);
     float getTimeState();
-    float getProgress();
-    E getState();
+    float getCurrentValue();
+    E getTarget();
 }

--- a/src/main/java/eu/midnightdust/blur/animations/IAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/IAnimationHandler.java
@@ -5,7 +5,7 @@ import eu.midnightdust.blur.config.BlurConfig;
 public interface IAnimationHandler<E extends Enum<E> & IEnumAnimationTarget> {
     void updateAnimation(float deltaSeconds, BlurConfig.Easing easing);
     void setTarget(E target);
-    int getFadeTimeMillis();
+    int getAnimationTimeMillis();
     float getTimeState();
     float getCurrentValue();
     E getTarget();

--- a/src/main/java/eu/midnightdust/blur/animations/IAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/IAnimationHandler.java
@@ -5,6 +5,7 @@ import eu.midnightdust.blur.config.BlurConfig;
 public interface IAnimationHandler<E extends Enum<E> & IEnumAnimationTarget> {
     void updateAnimation(float deltaSeconds, BlurConfig.Easing easing);
     void setTarget(E target);
+    int getFadeTimeMillis();
     float getTimeState();
     float getCurrentValue();
     E getTarget();

--- a/src/main/java/eu/midnightdust/blur/animations/IEnumAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/IEnumAnimationTarget.java
@@ -2,4 +2,5 @@ package eu.midnightdust.blur.animations;
 
 public interface IEnumAnimationTarget {
     float getAnimationTarget();
+    int getAnimationTimeMillis();
 }

--- a/src/main/java/eu/midnightdust/blur/animations/IEnumAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/IEnumAnimationTarget.java
@@ -1,0 +1,5 @@
+package eu.midnightdust.blur.animations;
+
+public interface IEnumAnimationTarget {
+    float getAnimationTarget();
+}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationHandler.java
@@ -1,0 +1,22 @@
+package eu.midnightdust.blur.animations.impl;
+
+import eu.midnightdust.blur.animations.AbstractAnimationHandler;
+import eu.midnightdust.blur.animations.IAnimationHandler;
+import eu.midnightdust.blur.config.BlurConfig;
+
+public class BackgroundAlphaAnimationHandler extends AbstractAnimationHandler<BackgroundAlphaAnimationTarget> implements IAnimationHandler<BackgroundAlphaAnimationTarget> {
+    @Override
+    public int getFadeTimeMillis() {
+        switch (getTarget()) {
+            case FadeIn -> {
+                return BlurConfig.fadeTimeMillis;
+            }
+            case FadeOut -> {
+                return BlurConfig.fadeOutTimeMillis;
+            }
+            case null -> {
+                return BlurConfig.fadeTimeMillis;
+            }
+        }
+    }
+}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationHandler.java
@@ -2,21 +2,6 @@ package eu.midnightdust.blur.animations.impl;
 
 import eu.midnightdust.blur.animations.AbstractAnimationHandler;
 import eu.midnightdust.blur.animations.IAnimationHandler;
-import eu.midnightdust.blur.config.BlurConfig;
 
 public class BackgroundAlphaAnimationHandler extends AbstractAnimationHandler<BackgroundAlphaAnimationTarget> implements IAnimationHandler<BackgroundAlphaAnimationTarget> {
-    @Override
-    public int getFadeTimeMillis() {
-        switch (getTarget()) {
-            case FadeIn -> {
-                return BlurConfig.fadeTimeMillis;
-            }
-            case FadeOut -> {
-                return BlurConfig.fadeOutTimeMillis;
-            }
-            case null -> {
-                return BlurConfig.fadeTimeMillis;
-            }
-        }
-    }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationTarget.java
@@ -2,7 +2,6 @@ package eu.midnightdust.blur.animations.impl;
 
 import eu.midnightdust.blur.animations.IEnumAnimationTarget;
 import eu.midnightdust.blur.config.BlurConfig;
-import net.minecraft.client.Minecraft;
 
 public enum BackgroundAlphaAnimationTarget implements IEnumAnimationTarget {
     FadeIn(1.0F),
@@ -16,5 +15,13 @@ public enum BackgroundAlphaAnimationTarget implements IEnumAnimationTarget {
 
     public float getAnimationTarget() {
         return target;
+    }
+
+    @Override
+    public int getAnimationTimeMillis() {
+        if (this == BackgroundAlphaAnimationTarget.FadeIn)
+            return BlurConfig.fadeTimeMillis;
+        else
+            return BlurConfig.fadeOutTimeMillis;
     }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BackgroundAlphaAnimationTarget.java
@@ -1,14 +1,16 @@
 package eu.midnightdust.blur.animations.impl;
 
 import eu.midnightdust.blur.animations.IEnumAnimationTarget;
+import eu.midnightdust.blur.config.BlurConfig;
+import net.minecraft.client.Minecraft;
 
-public enum FadeAnimationTarget implements IEnumAnimationTarget {
+public enum BackgroundAlphaAnimationTarget implements IEnumAnimationTarget {
     FadeIn(1.0F),
     FadeOut(0.0F);
 
     private final float target;
 
-    FadeAnimationTarget(float v) {
+    BackgroundAlphaAnimationTarget(float v) {
         target = v;
     }
 

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationHandler.java
@@ -1,0 +1,34 @@
+package eu.midnightdust.blur.animations.impl;
+
+import eu.midnightdust.blur.Blur;
+import eu.midnightdust.blur.animations.AbstractAnimationHandler;
+import eu.midnightdust.blur.animations.IAnimationHandler;
+import eu.midnightdust.blur.config.BlurConfig;
+
+public class BlurRadiusAnimationHandler extends AbstractAnimationHandler<BlurRadiusAnimationTarget> implements IAnimationHandler<BlurRadiusAnimationTarget> {
+    boolean prevReducedBlur = Blur.reducedBlur;
+
+    @Override
+    public int getFadeTimeMillis() {
+        switch (getTarget()) {
+            case FadeIn -> {
+                return BlurConfig.fadeTimeMillis;
+            }
+            case FadeOut -> {
+                return BlurConfig.fadeOutTimeMillis;
+            }
+            case null -> {
+                return BlurConfig.fadeTimeMillis;
+            }
+        }
+    }
+
+    @Override
+    public void updateAnimation(float deltaSeconds, BlurConfig.Easing easing) {
+        if (Blur.reducedBlur != prevReducedBlur) {
+            resetTarget(getTarget());
+            prevReducedBlur = Blur.reducedBlur;
+        }
+        super.updateAnimation(deltaSeconds, easing);
+    }
+}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationHandler.java
@@ -9,21 +9,6 @@ public class BlurRadiusAnimationHandler extends AbstractAnimationHandler<BlurRad
     boolean prevReducedBlur = Blur.reducedBlur;
 
     @Override
-    public int getFadeTimeMillis() {
-        switch (getTarget()) {
-            case FadeIn -> {
-                return BlurConfig.fadeTimeMillis;
-            }
-            case FadeOut -> {
-                return BlurConfig.fadeOutTimeMillis;
-            }
-            case null -> {
-                return BlurConfig.fadeTimeMillis;
-            }
-        }
-    }
-
-    @Override
     public void updateAnimation(float deltaSeconds, BlurConfig.Easing easing) {
         if (Blur.reducedBlur != prevReducedBlur) {
             resetTarget(getTarget());

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationTarget.java
@@ -3,7 +3,6 @@ package eu.midnightdust.blur.animations.impl;
 import eu.midnightdust.blur.Blur;
 import eu.midnightdust.blur.animations.IEnumAnimationTarget;
 import eu.midnightdust.blur.config.BlurConfig;
-import net.minecraft.client.Minecraft;
 
 public enum BlurRadiusAnimationTarget implements IEnumAnimationTarget {
     FadeIn(1.0F),
@@ -20,5 +19,13 @@ public enum BlurRadiusAnimationTarget implements IEnumAnimationTarget {
             return target * 0.5F;
         }
         return target;
+    }
+
+    @Override
+    public int getAnimationTimeMillis() {
+        if (this == BlurRadiusAnimationTarget.FadeIn)
+            return BlurConfig.fadeTimeMillis;
+        else
+            return BlurConfig.fadeOutTimeMillis;
     }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/BlurRadiusAnimationTarget.java
@@ -1,0 +1,24 @@
+package eu.midnightdust.blur.animations.impl;
+
+import eu.midnightdust.blur.Blur;
+import eu.midnightdust.blur.animations.IEnumAnimationTarget;
+import eu.midnightdust.blur.config.BlurConfig;
+import net.minecraft.client.Minecraft;
+
+public enum BlurRadiusAnimationTarget implements IEnumAnimationTarget {
+    FadeIn(1.0F),
+    FadeOut(0.0F);
+
+    private final float target;
+
+    BlurRadiusAnimationTarget(float v) {
+        target = v;
+    }
+
+    public float getAnimationTarget() {
+        if (Blur.reducedBlur) {
+            return target * 0.5F;
+        }
+        return target;
+    }
+}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationHandler.java
@@ -5,17 +5,5 @@ import eu.midnightdust.blur.animations.AnimationState;
 import eu.midnightdust.blur.animations.IAnimationHandler;
 import eu.midnightdust.blur.config.BlurConfig;
 
-public class FadeAnimationHandler extends AbstractAnimationHandler<FadeAnimationState> implements IAnimationHandler<FadeAnimationState> {
-    @Override
-    public AnimationState stepAnimation(float deltaSeconds, BlurConfig.Easing easing, AnimationState oldAnimationState) {
-        switch (getState()) {
-            case FadeIn -> {
-                return this.stepForward(deltaSeconds, easing, oldAnimationState);
-            }
-            case FadeOut -> {
-                return this.stepBackward(deltaSeconds, easing, oldAnimationState);
-            }
-        }
-        return oldAnimationState;
-    }
+public class FadeAnimationHandler extends AbstractAnimationHandler<FadeAnimationTarget> implements IAnimationHandler<FadeAnimationTarget> {
 }

--- a/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationHandler.java
@@ -1,9 +1,0 @@
-package eu.midnightdust.blur.animations.impl;
-
-import eu.midnightdust.blur.animations.AbstractAnimationHandler;
-import eu.midnightdust.blur.animations.AnimationState;
-import eu.midnightdust.blur.animations.IAnimationHandler;
-import eu.midnightdust.blur.config.BlurConfig;
-
-public class FadeAnimationHandler extends AbstractAnimationHandler<FadeAnimationTarget> implements IAnimationHandler<FadeAnimationTarget> {
-}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationState.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationState.java
@@ -1,6 +1,0 @@
-package eu.midnightdust.blur.animations.impl;
-
-public enum FadeAnimationState {
-    FadeIn,
-    FadeOut
-}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/FadeAnimationTarget.java
@@ -1,0 +1,18 @@
+package eu.midnightdust.blur.animations.impl;
+
+import eu.midnightdust.blur.animations.IEnumAnimationTarget;
+
+public enum FadeAnimationTarget implements IEnumAnimationTarget {
+    FadeIn(1.0F),
+    FadeOut(0.0F);
+
+    private final float target;
+
+    FadeAnimationTarget(float v) {
+        target = v;
+    }
+
+    public float getAnimationTarget() {
+        return target;
+    }
+}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationHandler.java
@@ -1,5 +1,6 @@
 package eu.midnightdust.blur.animations.impl;
 
+import eu.midnightdust.blur.Blur;
 import eu.midnightdust.blur.animations.AbstractAnimationHandler;
 import eu.midnightdust.blur.animations.AnimationState;
 import eu.midnightdust.blur.animations.IAnimationHandler;
@@ -7,32 +8,25 @@ import eu.midnightdust.blur.config.BlurConfig;
 import eu.midnightdust.lib.util.MidnightColorUtil;
 
 import java.awt.*;
+import java.util.Objects;
 
-public class GradientAnimationHandler extends AbstractAnimationHandler<GradientAnimationState> implements IAnimationHandler<GradientAnimationState> {
+public class GradientAnimationHandler extends AbstractAnimationHandler<GradientAnimationTarget> implements IAnimationHandler<GradientAnimationTarget> {
     private static float rotation = (float) BlurConfig.gradientRotation;
     private static float hue1 = 0.0F;
     private static float hue2 = 0.35F;
 
     @Override
-    public AnimationState stepAnimation(float deltaSeconds, BlurConfig.Easing easing, AnimationState oldAnimationState) {
-        AnimationState newAnimationState = oldAnimationState;
-        switch (getState()) {
-            case Rainbow -> {
-                newAnimationState = this.stepForward(deltaSeconds, easing, oldAnimationState);
+    public AnimationState<GradientAnimationTarget> stepAnimation(float deltaSeconds, BlurConfig.Easing easing) {
+        GradientAnimationTarget target = getTarget();
+        if (target == GradientAnimationTarget.Rainbow) {
+            // 20 degrees of rotation per second (or 1 degree per tick, same as before)
+            rotation = (rotation + deltaSeconds * 20F) % 360F;
 
-                // 20 degrees of rotation per second (or 1 degree per tick, same as before)
-                rotation = (rotation + deltaSeconds * 20F) % 360F;
-
-                // 72 degrees of rotation per second (or 3.6 degree per tick, same as before)
-                hue1 = (hue1 + deltaSeconds * 0.2F) % 1.0F;
-                hue2 = (hue2 + deltaSeconds * 0.2F) % 1.0F;
-            }
-            case Fixed -> {
-                newAnimationState = this.stepBackward(deltaSeconds, easing, oldAnimationState);
-            }
+            // 72 degrees of rotation per second (or 3.6 degree per tick, same as before)
+            hue1 = (hue1 + deltaSeconds * 0.2F) % 1.0F;
+            hue2 = (hue2 + deltaSeconds * 0.2F) % 1.0F;
         }
-
-        return newAnimationState;
+        return super.stepAnimation(deltaSeconds, easing);
     }
 
     public Color getFirstColor() {
@@ -40,9 +34,9 @@ public class GradientAnimationHandler extends AbstractAnimationHandler<GradientA
         Color fixedColor = MidnightColorUtil.hex2Rgb(BlurConfig.gradientStart);
 
         return new Color(
-                (rainbowColor.getRed() / 255F) * getProgress() + (fixedColor.getRed() / 255F) * (1 - getProgress()),
-                (rainbowColor.getGreen() / 255F) * getProgress() + (fixedColor.getGreen() / 255F) * (1 - getProgress()),
-                (rainbowColor.getBlue() / 255F) * getProgress() + (fixedColor.getBlue() / 255F) * (1 - getProgress()),
+                (rainbowColor.getRed() / 255F) * getCurrentValue() + (fixedColor.getRed() / 255F) * (1 - getCurrentValue()),
+                (rainbowColor.getGreen() / 255F) * getCurrentValue() + (fixedColor.getGreen() / 255F) * (1 - getCurrentValue()),
+                (rainbowColor.getBlue() / 255F) * getCurrentValue() + (fixedColor.getBlue() / 255F) * (1 - getCurrentValue()),
                 BlurConfig.gradientStartAlpha / 255F
         );
     }
@@ -52,9 +46,9 @@ public class GradientAnimationHandler extends AbstractAnimationHandler<GradientA
         Color fixedColor = MidnightColorUtil.hex2Rgb(BlurConfig.gradientEnd);
 
         return new Color(
-                (rainbowColor.getRed() / 255F) * getProgress() + (fixedColor.getRed() / 255F) * (1 - getProgress()),
-                (rainbowColor.getGreen() / 255F) * getProgress() + (fixedColor.getGreen() / 255F) * (1 - getProgress()),
-                (rainbowColor.getBlue() / 255F) * getProgress() + (fixedColor.getBlue() / 255F) * (1 - getProgress()),
+                (rainbowColor.getRed() / 255F) * getCurrentValue() + (fixedColor.getRed() / 255F) * (1 - getCurrentValue()),
+                (rainbowColor.getGreen() / 255F) * getCurrentValue() + (fixedColor.getGreen() / 255F) * (1 - getCurrentValue()),
+                (rainbowColor.getBlue() / 255F) * getCurrentValue() + (fixedColor.getBlue() / 255F) * (1 - getCurrentValue()),
                 BlurConfig.gradientEndAlpha / 255F
         );
     }
@@ -63,6 +57,6 @@ public class GradientAnimationHandler extends AbstractAnimationHandler<GradientA
         float rainbowRotation = rotation;
         float fixedRotation = BlurConfig.gradientRotation;
 
-        return rainbowRotation * getProgress() + fixedRotation * (1 - getProgress());
+        return rainbowRotation * getCurrentValue() + fixedRotation * (1 - getCurrentValue());
     }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationHandler.java
@@ -14,21 +14,6 @@ public class GradientAnimationHandler extends AbstractAnimationHandler<GradientA
     private static float hue2 = 0.35F;
 
     @Override
-    public int getFadeTimeMillis() {
-        switch (getTarget()) {
-            case Rainbow -> {
-                return BlurConfig.fadeTimeMillis;
-            }
-            case Fixed -> {
-                return BlurConfig.fadeOutTimeMillis;
-            }
-            case null -> {
-                return BlurConfig.fadeTimeMillis;
-            }
-        }
-    }
-
-    @Override
     public AnimationState<GradientAnimationTarget> stepAnimation(float deltaSeconds, BlurConfig.Easing easing) {
         GradientAnimationTarget target = getTarget();
         if (target == GradientAnimationTarget.Rainbow) {

--- a/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationHandler.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationHandler.java
@@ -1,6 +1,5 @@
 package eu.midnightdust.blur.animations.impl;
 
-import eu.midnightdust.blur.Blur;
 import eu.midnightdust.blur.animations.AbstractAnimationHandler;
 import eu.midnightdust.blur.animations.AnimationState;
 import eu.midnightdust.blur.animations.IAnimationHandler;
@@ -8,12 +7,26 @@ import eu.midnightdust.blur.config.BlurConfig;
 import eu.midnightdust.lib.util.MidnightColorUtil;
 
 import java.awt.*;
-import java.util.Objects;
 
 public class GradientAnimationHandler extends AbstractAnimationHandler<GradientAnimationTarget> implements IAnimationHandler<GradientAnimationTarget> {
     private static float rotation = (float) BlurConfig.gradientRotation;
     private static float hue1 = 0.0F;
     private static float hue2 = 0.35F;
+
+    @Override
+    public int getFadeTimeMillis() {
+        switch (getTarget()) {
+            case Rainbow -> {
+                return BlurConfig.fadeTimeMillis;
+            }
+            case Fixed -> {
+                return BlurConfig.fadeOutTimeMillis;
+            }
+            case null -> {
+                return BlurConfig.fadeTimeMillis;
+            }
+        }
+    }
 
     @Override
     public AnimationState<GradientAnimationTarget> stepAnimation(float deltaSeconds, BlurConfig.Easing easing) {

--- a/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationState.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationState.java
@@ -1,6 +1,0 @@
-package eu.midnightdust.blur.animations.impl;
-
-public enum GradientAnimationState {
-    Fixed,
-    Rainbow
-}

--- a/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationTarget.java
@@ -1,6 +1,7 @@
 package eu.midnightdust.blur.animations.impl;
 
 import eu.midnightdust.blur.animations.IEnumAnimationTarget;
+import eu.midnightdust.blur.config.BlurConfig;
 
 public enum GradientAnimationTarget implements IEnumAnimationTarget {
     Fixed(0.0F),
@@ -14,5 +15,13 @@ public enum GradientAnimationTarget implements IEnumAnimationTarget {
 
     public float getAnimationTarget() {
         return target;
+    }
+
+    @Override
+    public int getAnimationTimeMillis() {
+        if (this == GradientAnimationTarget.Rainbow)
+            return BlurConfig.fadeTimeMillis;
+        else
+            return BlurConfig.fadeOutTimeMillis;
     }
 }

--- a/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationTarget.java
+++ b/src/main/java/eu/midnightdust/blur/animations/impl/GradientAnimationTarget.java
@@ -1,0 +1,18 @@
+package eu.midnightdust.blur.animations.impl;
+
+import eu.midnightdust.blur.animations.IEnumAnimationTarget;
+
+public enum GradientAnimationTarget implements IEnumAnimationTarget {
+    Fixed(0.0F),
+    Rainbow(1.0F);
+
+    private final float target;
+
+    GradientAnimationTarget(float v) {
+        target = v;
+    }
+
+    public float getAnimationTarget() {
+        return target;
+    }
+}

--- a/src/main/java/eu/midnightdust/blur/config/BlurConfig.java
+++ b/src/main/java/eu/midnightdust/blur/config/BlurConfig.java
@@ -37,6 +37,8 @@ public class BlurConfig extends MidnightConfig {
     public static boolean blurTitleScreen = false;
     @Entry(category = SCREENS)
     public static boolean darkenTitleScreen = false;
+    @Entry(category = SCREENS)
+    public static boolean reduceInGameBlur = false;
     @Comment(category = SCREENS, centered = true)
     public static Comment _advanced;
     @Entry(category = SCREENS)
@@ -70,9 +72,9 @@ public class BlurConfig extends MidnightConfig {
 
     @Comment(category = ANIMATIONS, centered = true)
     public static Comment _animations;
-    @Entry(category = ANIMATIONS, min = 0, max = 2000, isSlider = true)
+    @Entry(category = ANIMATIONS, min = 1, max = 2000, isSlider = true)
     public static int fadeTimeMillis = 300;
-    @Entry(category = ANIMATIONS, min = 0, max = 2000, isSlider = true)
+    @Entry(category = ANIMATIONS, min = 1, max = 2000, isSlider = true)
     public static int fadeOutTimeMillis = 300;
     @Entry(category = ANIMATIONS)
     public static BlurConfig.Easing blurAnimationCurve = Easing.FLAT;

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinAbstractCommandBlockEditScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinAbstractCommandBlockEditScreen.java
@@ -21,6 +21,7 @@ public class MixinAbstractCommandBlockEditScreen extends Screen {
     //~ if >= 26.1 'GuiGraphics' -> 'GuiGraphicsExtractor' {
     //~ if >= 26.1 'render' -> 'extract' {
     private void blur$extractContainerBlur(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) { // Applies the blur effect in containers (Inventory, Chest, etc.)
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurCommandBlocks && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
     }
     //~}

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinAbstractContainerScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinAbstractContainerScreen.java
@@ -1,5 +1,6 @@
 package eu.midnightdust.blur.mixin;
 
+import eu.midnightdust.blur.Blur;
 import eu.midnightdust.blur.config.BlurConfig;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -30,6 +31,7 @@ public class MixinAbstractContainerScreen extends Screen {
     *///?} else {
     @ModifyReturnValue(method = "isInGameUi", at = @At("RETURN"))
     public boolean blur$isInGameUi(boolean original) {
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurContainers) return false;
         else return original;
     }

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinAbstractSignEditScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinAbstractSignEditScreen.java
@@ -22,6 +22,7 @@ public class MixinAbstractSignEditScreen extends Screen {
     @Inject(method = /*? if >= 26.1 {*/"extractRenderState"/*?} else if > 1.21.5 {*//*"render"*//*?} else {*/ /*"renderBackground" *//*?}*/, at = @At(value = "TAIL"))
     //~ if >= 26.1 'render' -> 'extract' {
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurSigns && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
     }
     //~}

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinBookEditScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinBookEditScreen.java
@@ -28,6 +28,7 @@ public class MixinBookEditScreen extends Screen {
             )
     )
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurBooks && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
     }
     //~}

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinBookSignScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinBookSignScreen.java
@@ -28,6 +28,7 @@ public class MixinBookSignScreen extends Screen {
             )
     )
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurBooks && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
     }
     //~}

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinBookViewScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinBookViewScreen.java
@@ -28,6 +28,7 @@ public class MixinBookViewScreen extends Screen {
             )
     )
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurBooks && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
     }
     //~}

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinDeathScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinDeathScreen.java
@@ -29,6 +29,7 @@ public class MixinDeathScreen extends Screen {
             )
     )
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
         if (BlurConfig.blurDeathScreen && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
     }
     //~}
@@ -50,6 +51,7 @@ public class MixinDeathScreen extends Screen {
                 )
         )
         private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+            if (BlurConfig.reduceInGameBlur) Blur.reducedBlur = true;
             if (BlurConfig.blurDeathScreen && Blur.canBlur(context)) this.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
         }
         //~}

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinOptions.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinOptions.java
@@ -27,6 +27,6 @@ public abstract class MixinOptions {
     // applies our blur radius coefficient to getMenuBackgroundBlurriness method
     @ModifyReturnValue(method = "getMenuBackgroundBlurriness", at = @At(value = "RETURN"))
     private int blur$applyMenuBackgroundBlurCoefficient(int original) {
-        return (int) (original * Blur.blurRadiusAnimation.getProgress());
+        return (int) (original * Blur.blurRadiusAnimation.getCurrentValue());
     }
 }

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinScreen.java
@@ -2,7 +2,7 @@ package eu.midnightdust.blur.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import eu.midnightdust.blur.animations.impl.FadeAnimationState;
+import eu.midnightdust.blur.animations.impl.FadeAnimationTarget;
 import eu.midnightdust.blur.config.BlurConfig;
 import eu.midnightdust.blur.util.DebugHudRenderer;
 import net.minecraft.client.Minecraft;
@@ -51,7 +51,7 @@ public abstract class MixinScreen {
     public void blur$onRenderBlurredBackground(CallbackInfo ci) {
         // if the screen tries to call `renderBlurredBackground` we can determine the screen had a blurred background,
         // and we can set the blur animation to fade-in mode
-        Blur.blurRadiusAnimation.setState(FadeAnimationState.FadeIn);
+        Blur.blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeIn);
     }
 
     @Inject(
@@ -76,7 +76,7 @@ public abstract class MixinScreen {
     private void blur$onRenderBackground(GuiGraphicsExtractor context) {
         // if the screen tries to call this function we can determine the screen had a background, and we can set the
         // background animation to fade-in mode
-        Blur.backgroundAlphaAnimation.setState(FadeAnimationState.FadeIn);
+        Blur.backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeIn);
 
         // also draw a blurred background for forceEnabledScreens that are not also in forceDisabledScreens and only if
         // we can apply blur at all, this must be before we draw the background

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinScreen.java
@@ -2,7 +2,8 @@ package eu.midnightdust.blur.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import eu.midnightdust.blur.animations.impl.FadeAnimationTarget;
+import eu.midnightdust.blur.animations.impl.BackgroundAlphaAnimationTarget;
+import eu.midnightdust.blur.animations.impl.BlurRadiusAnimationTarget;
 import eu.midnightdust.blur.config.BlurConfig;
 import eu.midnightdust.blur.util.DebugHudRenderer;
 import net.minecraft.client.Minecraft;
@@ -51,7 +52,7 @@ public abstract class MixinScreen {
     public void blur$onRenderBlurredBackground(CallbackInfo ci) {
         // if the screen tries to call `renderBlurredBackground` we can determine the screen had a blurred background,
         // and we can set the blur animation to fade-in mode
-        Blur.blurRadiusAnimation.setTarget(FadeAnimationTarget.FadeIn);
+        Blur.blurRadiusAnimation.setTarget(BlurRadiusAnimationTarget.FadeIn);
     }
 
     @Inject(
@@ -76,7 +77,7 @@ public abstract class MixinScreen {
     private void blur$onRenderBackground(GuiGraphicsExtractor context) {
         // if the screen tries to call this function we can determine the screen had a background, and we can set the
         // background animation to fade-in mode
-        Blur.backgroundAlphaAnimation.setTarget(FadeAnimationTarget.FadeIn);
+        Blur.backgroundAlphaAnimation.setTarget(BackgroundAlphaAnimationTarget.FadeIn);
 
         // also draw a blurred background for forceEnabledScreens that are not also in forceDisabledScreens and only if
         // we can apply blur at all, this must be before we draw the background

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinTitleScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinTitleScreen.java
@@ -1,7 +1,7 @@
 package eu.midnightdust.blur.mixin;
 
 import eu.midnightdust.blur.Blur;
-import eu.midnightdust.blur.animations.impl.FadeAnimationState;
+import eu.midnightdust.blur.animations.impl.FadeAnimationTarget;
 import eu.midnightdust.blur.config.BlurConfig;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
@@ -25,9 +25,9 @@ public abstract class MixinTitleScreen extends Screen {
     //~ if >= 26.1 'GuiGraphics' -> 'GuiGraphicsExtractor'
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         if (Blur.canBlur(context)) super.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
-        Blur.blurRadiusAnimation.setState(BlurConfig.blurTitleScreen ? FadeAnimationState.FadeIn : FadeAnimationState.FadeOut);
+        Blur.blurRadiusAnimation.setTarget(BlurConfig.blurTitleScreen ? FadeAnimationTarget.FadeIn : FadeAnimationTarget.FadeOut);
         if (BlurConfig.useGradient) super.extractMenuBackground(context);
-        Blur.backgroundAlphaAnimation.setState(BlurConfig.darkenTitleScreen ? FadeAnimationState.FadeIn : FadeAnimationState.FadeOut);
+        Blur.backgroundAlphaAnimation.setTarget(BlurConfig.darkenTitleScreen ? FadeAnimationTarget.FadeIn : FadeAnimationTarget.FadeOut);
     }
     //~}
 }

--- a/src/main/java/eu/midnightdust/blur/mixin/MixinTitleScreen.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/MixinTitleScreen.java
@@ -1,7 +1,8 @@
 package eu.midnightdust.blur.mixin;
 
 import eu.midnightdust.blur.Blur;
-import eu.midnightdust.blur.animations.impl.FadeAnimationTarget;
+import eu.midnightdust.blur.animations.impl.BackgroundAlphaAnimationTarget;
+import eu.midnightdust.blur.animations.impl.BlurRadiusAnimationTarget;
 import eu.midnightdust.blur.config.BlurConfig;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
@@ -25,9 +26,9 @@ public abstract class MixinTitleScreen extends Screen {
     //~ if >= 26.1 'GuiGraphics' -> 'GuiGraphicsExtractor'
     private void blur$extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         if (Blur.canBlur(context)) super.extractBlurredBackground(/*? if > 1.21.5 {*/ context /*?} else if <= 1.21.1 {*/ /*delta *//*?}*/);
-        Blur.blurRadiusAnimation.setTarget(BlurConfig.blurTitleScreen ? FadeAnimationTarget.FadeIn : FadeAnimationTarget.FadeOut);
+        Blur.blurRadiusAnimation.setTarget(BlurConfig.blurTitleScreen ? BlurRadiusAnimationTarget.FadeIn : BlurRadiusAnimationTarget.FadeOut);
         if (BlurConfig.useGradient) super.extractMenuBackground(context);
-        Blur.backgroundAlphaAnimation.setTarget(BlurConfig.darkenTitleScreen ? FadeAnimationTarget.FadeIn : FadeAnimationTarget.FadeOut);
+        Blur.backgroundAlphaAnimation.setTarget(BlurConfig.darkenTitleScreen ? BackgroundAlphaAnimationTarget.FadeIn : BackgroundAlphaAnimationTarget.FadeOut);
     }
     //~}
 }

--- a/src/main/resources/assets/blur/lang/en_us.json
+++ b/src/main/resources/assets/blur/lang/en_us.json
@@ -9,6 +9,7 @@
   "blur.midnightconfig.blurDeathScreen": "Apply Blur to Death Screen",
   "blur.midnightconfig.blurSigns": "Apply Blur to Signs",
   "blur.midnightconfig.blurTitleScreen": "Apply Blur to Title Screen",
+  "blur.midnightconfig.reduceInGameBlur": "Reduce Blur on In-Game Screens",
   "blur.midnightconfig.darkenTitleScreen": "Darken Title Screen Background",
   "blur.midnightconfig.fadeTimeMillis": "Fade Time (in milliseconds)",
   "blur.midnightconfig.fadeOutTimeMillis": "Fade Out Time (in milliseconds)",


### PR DESCRIPTION
This PR Refactors `AbstractAnimationHandler` to:

1. **allow for any number of animation targets**: As a result we can animate to any arbitrary coefficient, so I've added the "Reduce Blur on In-Game Screens" option (off by default)
2. **animations are **always** Continuous**: No matter the animation curve or how many times it gets interrupted, animations always stay continuous. Previously only the "Flat" curve was truly Continuous.

Side effects of this refactor is that the animation duration can't be zero, so the `fadeTimeMillis` and `fadeOutTimeMillis` minimum value is now set to 1 instead of 0. we can also have as many animation times for each animation target.