### PR TITLE
[fix] crash when trying to render screens inside screens

### DIFF
--- a/src/main/java/eu/midnightdust/blur/mixin/GuiRenderStateMixin.java
+++ b/src/main/java/eu/midnightdust/blur/mixin/GuiRenderStateMixin.java
@@ -1,0 +1,47 @@
+package eu.midnightdust.blur.mixin;
+
+//? if > 1.21.5 {
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+//~ if >= 26.1 'net.minecraft.client.gui.render.state.GuiRenderState' -> 'net.minecraft.client.renderer.state.gui.GuiRenderState'
+import net.minecraft.client.renderer.state.gui.GuiRenderState;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+
+@Mixin(GuiRenderState.class)
+public class GuiRenderStateMixin {
+    @Shadow
+    private int firstStratumAfterBlur;
+
+    @Shadow
+    @Final
+    private List<?> strata;
+
+    @WrapMethod(method = "blurBeforeThisStratum")
+    void blur$dontPanicOverMultipleBlurLayers(Operation<Void> original) {
+        // Minecraft doesn't allow blurBeforeThisStratum to be called multiple times per frame,
+        // and crashes when this function is called multiple times.
+        //
+        // we change the behavior, so when blurBeforeThisStratum is called multiple times, it only applies the last blur
+        // layer and ignores the ones below it, resulting in the closest final image to what the programmer expects.
+        //
+        // Fixes all the "can only blur once per frame" crashes
+
+        // reset firstStratumAfterBlur
+        firstStratumAfterBlur = Integer.MAX_VALUE;
+
+        // call the original function for compatibility with other mods that modify it
+        original.call();
+    }
+}
+//?} else {
+/*import eu.midnightdust.core.MidnightLib;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(MidnightLib.class)
+public interface GuiRenderStateMixin {
+}
+*///?}

--- a/src/main/resources/blur.mixins.json
+++ b/src/main/resources/blur.mixins.json
@@ -6,6 +6,7 @@
   "client": [
     "GuiGraphicsAccessor",
     "GuiRenderStateAccessor",
+    "GuiRenderStateMixin",
     "MixinAbstractCommandBlockEditScreen",
     "MixinAbstractContainerScreen",
     "MixinAbstractSignEditScreen",


### PR DESCRIPTION
Fixes the "can only blur once per frame" crash in any scenario when the blur is being applied multiple times, whether on accident or intentionally, we now modify `GuiRenderState`, so it can never produce this crash:

Minecraft doesn't allow `GuiRenderState.blurBeforeThisStratum` to be called multiple times per frame, because it can only proccess blur once per each frame, so it crashes when this function is called multiple times, but there's a better alternative to just crashing. Instead, when `GuiRenderState.blurBeforeThisStratum` is called multiple times, it now only applies the last blur layer and ignores the ones below it, resulting in the closest final image to what the programmer expects.

This mainly fixes crashes when a screen has other screens inside it, for example when the `FriendsOverlayScreen` is rendered with a background screen that has blur already.